### PR TITLE
chore: Repository Rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ resolver = "2"
 edition = "2021"
 license = "MIT"
 authors = ["Eric Woolsey<ewoolsey@ualberta.ca>", "refcell"]
-repository = "https://github.com/ethereum-optimism/op-test-vectors"
-homepage = "https://github.com/ethereum-optimism/op-test-vectors"
-exclude = ["**/target", "benches/", "tests"]
+repository = "https://github.com/ethereum-optimism/tests"
+homepage = "https://github.com/ethereum-optimism/tests"
+exclude = ["**/target", "benches/"]
 
 [workspace.dependencies]
 # General

--- a/README.md
+++ b/README.md
@@ -7,30 +7,32 @@
 </h4>
 
 <p align="center">
-  <a href="https://github.com/ethereum-optimism/op-test-vectors/actions/workflows/ci.yml"><img src="https://github.com/ethereum-optimism/op-test-vectors/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
-  <a href="https://github.com/ethereum-optimism/op-test-vectors/actions/workflows/book.yml"><img src="https://github.com/ethereum-optimism/op-test-vectors/actions/workflows/book.yml/badge.svg?label=Book" alt="Book"></a>
+  <a href="https://github.com/ethereum-optimism/tests/actions/workflows/ci.yml"><img src="https://github.com/ethereum-optimism/tests/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+  <a href="https://github.com/ethereum-optimism/tests/actions/workflows/book.yml"><img src="https://github.com/ethereum-optimism/tests/actions/workflows/book.yml/badge.svg?label=Book" alt="Book"></a>
   <img src="https://img.shields.io/badge/License-MIT-green.svg?label=license&labelColor=2a2f35" alt="License">
-  <a href="https://ethereum-optimism.github.io/op-test-vectors"><img src="https://img.shields.io/badge/Contributor%20Book-854a15?logo=mdBook&labelColor=2a2f35" alt="Book"></a>
+  <a href="https://ethereum-optimism.github.io/tests"><img src="https://img.shields.io/badge/Contributor%20Book-854a15?logo=mdBook&labelColor=2a2f35" alt="Book"></a>
 </p>
 
 <p align="center">
-  <a href="#whats-op-test-vectors">What's OP Test Vectors?</a> •
+  <a href="#whats-ethereum-optimism/tests">What's `ethereum-optimism/tests`</a> •
   <a href="#overview">Overview</a> •
-  <a href="https://static.optimism.io/op-test-vectors/CONTRIBUTING.html">Contributing</a> •
+  <a href="https://static.optimism.io/tests/CONTRIBUTING.html">Contributing</a> •
   <a href="#credits">Credits</a>
 </p>
 
-## What's OP Test Vectors?
+## What's `ethereum-optimism/tests`?
 
-OP Test Vectors is a portable suite of standardized test fixtures used to test OP Stack component implementations.
+`ethereum-optimism/tests` is a portable suite of standardized test fixtures used to test OP Stack component implementations. Test fixtures are static JSON files defined in the [fixtures](./fixtures) directory.
 
-Test fixtures are static JSON files defined in the [fixtures](./fixtures) directory.
+There are two types of tests:
+- `derivation`
+- `execution`
 
-Test fixtures can be easily generated using the [opt8n](./crates/opt8n) cli tool.
+Each has it's own cli tool to generate test fixtures. [opt8n](./bin/opt8n) can be used to generate execution test fixtures, while [opdn](./bin/opdn) generates derivation test fixtures.
 
 ### Development Status
 
-`op-test-vectors` is currently in active development, and is not yet ready for use in production.
+`ethereum-optimism/tests` is currently in active development, and is not yet ready for use in production.
 
 ## Overview
 
@@ -50,9 +52,9 @@ The [book][book] contains an in-depth overview of the project, contributor guide
 
 ## Credits
 
-`op-test-vectors` is inspired by [ethereum/tests][eth-tests] and built by the collaboration between a number of teams and external contributors including [OP Labs][op-labs] and [Worldcoin engineers][worldcoin].
+`ethereum-optimism/tests` is inspired by [ethereum/tests][eth-tests] and built by the collaboration between a number of teams and external contributors including [OP Labs][op-labs] and [Worldcoin engineers][worldcoin].
 
-[book]: https://ethereum-optimism.github.io/op-test-vectors/
+[book]: https://ethereum-optimism.github.io/tests/
 [op-labs]: https://github.com/ethereum-optimism
 [worldcoin]: https://github.com/worldcoin
 [eth-tests]: https://github.com/ethereum/tests

--- a/book/README.md
+++ b/book/README.md
@@ -1,7 +1,7 @@
 # OP Test Vectors Book
 
 This repository contains the source code for the OP Test vectors book,
-which is available at [ethereum-optimism.github.io/op-test-vectors](https://ethereum-optimism.github.io/op-test-vectors/).
+which is available at [ethereum-optimism.github.io/tests](https://ethereum-optimism.github.io/tests/).
 
 ## Contributing
 

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -1,18 +1,18 @@
-# OP Test Vectors Book
+# Optimism Test Book
 
-_Documentation for the op-test-vectors repository._
+_Documentation for the ethereum-optimism/tests repository._
 
 ## Introduction
 
-OP Test Vectors is a collection of test fixtures for testing OP Stack execution and derivation.
-Alongside test fixtures, the op-test-fixtures repository contains a CLI tool for generating new
+`ethereum-optimsim/tests` is a collection of test fixtures for testing OP Stack execution and derivation.
+Alongside test fixtures, the `ethereum-optimism/tests` repository contains CLI tools for generating new
 test fixtures written in Rust with the goal of making test fixture generation simple.
 
 It is built and maintained by members of [OP Labs][op-labs] as well as open source contributors,
 and is licensed under the MIT License.
 
-OP Test Vectors is comparible to the [ethereum-tests][ethereum-tests] repository for ethereum.
-The aim of [op-test-vectors][op-test-vectors] is then to provide a set of standard tests for all
+`ethereum-optimsim/tests` is comparible to the [ethereum-tests][ethereum-tests] repository for ethereum.
+The aim of [ethereum-optimism/tests][tests] is then to provide a set of standard tests for all
 OP Stack client and node software to use for testing. In order to run these test fixtures against
 various execution and derivation implementations, each instance must implement their own test runner.
 For example, similar to how [revm][revm] defines a test runner, [revme][revme], to run the
@@ -24,7 +24,7 @@ intentionally portable to other languages over the JSON interface.
 
 ## Development Status
 
-**OP Test Vectors is currently in active development, and is not yet ready for use in production.**
+**`ethereum-optimism/tests` is currently in active development, and is not yet ready for use in production.**
 
 ## Contributing
 

--- a/book/src/links.md
+++ b/book/src/links.md
@@ -8,11 +8,11 @@
 
 <!-- Kona links -->
 
-[op-test-vectors]: https://github.com/ethereum-optimism/op-test-vectors
-[book]: https://ethereum-optimism.github.io/op-test-vectors/
-[issues]: https://github.com/ethereum-optimism/op-test-vectors/issues
-[new-issue]: https://github.com/ethereum-optimism/op-test-vectors/issues/new
-[contributing]: https://github.com/ethereum-optimism/op-test-vectors/tree/main/CONTRIBUTING.md
+[op-test-vectors]: https://github.com/ethereum-optimism/tests
+[book]: https://ethereum-optimism.github.io/tests/
+[issues]: https://github.com/ethereum-optimism/tests/issues
+[new-issue]: https://github.com/ethereum-optimism/tests/issues/new
+[contributing]: https://github.com/ethereum-optimism/tests/tree/main/CONTRIBUTING.md
 
 <!-- People -->
 

--- a/book/src/links.md
+++ b/book/src/links.md
@@ -8,11 +8,12 @@
 
 <!-- Kona links -->
 
-[op-test-vectors]: https://github.com/ethereum-optimism/tests
+[tests]: https://github.com/ethereum-optimism/tests
 [book]: https://ethereum-optimism.github.io/tests/
 [issues]: https://github.com/ethereum-optimism/tests/issues
 [new-issue]: https://github.com/ethereum-optimism/tests/issues/new
 [contributing]: https://github.com/ethereum-optimism/tests/tree/main/CONTRIBUTING.md
+[op-test-vectors]: https://github.com/ethereum-optimism/tests/tree/main/crates/op-test-vectors
 
 <!-- People -->
 


### PR DESCRIPTION
**Description**

Updates docs for the repository rename from `op-test-vectors` to `tests`.

Leaves the crate name as `op-test-vectors`.