### PR TITLE
feat(optv): Generic Derivation Test Fixtures

### DIFF
--- a/bin/opdn/src/cmd/fixtures.rs
+++ b/bin/opdn/src/cmd/fixtures.rs
@@ -8,6 +8,7 @@ use kona_derive::online::{
     AlloyChainProvider, OnlineBeaconClient, OnlineBlobProviderWithFallback, SimpleSlotDerivation,
 };
 use kona_derive::traits::ChainProvider;
+use kona_derive::types::Blob;
 use op_test_vectors::derivation::FixtureBlock;
 
 /// Constructs [FixtureBlock]s for the given L1 blocks.
@@ -21,7 +22,7 @@ pub async fn build_fixture_blocks(
         OnlineBeaconClient,
         SimpleSlotDerivation,
     >,
-) -> Result<Vec<FixtureBlock>> {
+) -> Result<Vec<FixtureBlock<Blob>>> {
     let mut fixtures = Vec::with_capacity(blocks.len());
     for b in blocks {
         let block_info = l1_provider

--- a/crates/op-test-vectors/Cargo.toml
+++ b/crates/op-test-vectors/Cargo.toml
@@ -26,7 +26,7 @@ alloy-consensus.workspace = true
 # OP Types
 op-alloy-rpc-types.workspace = true
 op-alloy-consensus.workspace = true
-kona-derive.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+kona-derive.workspace = true

--- a/crates/op-test-vectors/src/derivation.rs
+++ b/crates/op-test-vectors/src/derivation.rs
@@ -13,11 +13,11 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 )]
 #[serde(rename_all = "camelCase")]
 pub struct DerivationFixture<
-    RollupConfig: DeserializeOwned,
-    L2PayloadAttributes: DeserializeOwned,
-    SystemConfig: DeserializeOwned,
-    L2BlockInfo: DeserializeOwned,
-    Blob: DeserializeOwned,
+    RollupConfig: DeserializeOwned + Serialize,
+    L2PayloadAttributes: DeserializeOwned + Serialize,
+    SystemConfig: DeserializeOwned + Serialize,
+    L2BlockInfo: DeserializeOwned + Serialize,
+    Blob: DeserializeOwned + Serialize,
 > {
     /// The rollup config.
     pub rollup_config: RollupConfig,
@@ -46,7 +46,7 @@ pub struct DerivationFixture<
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 #[serde(bound = "Blob: Serialize + DeserializeOwned")]
 #[serde(rename_all = "camelCase")]
-pub struct FixtureBlock<Blob: DeserializeOwned> {
+pub struct FixtureBlock<Blob: DeserializeOwned + Serialize> {
     /// The block header.
     /// The entire header is required to generate the block hash when deriving the l1 block info
     /// tx.

--- a/crates/op-test-vectors/src/derivation.rs
+++ b/crates/op-test-vectors/src/derivation.rs
@@ -3,18 +3,26 @@
 use alloy_consensus::{Header, Receipt};
 use alloy_primitives::Bytes;
 use hashbrown::HashMap;
-use kona_derive::types::{Blob, L2BlockInfo, L2PayloadAttributes, RollupConfig, SystemConfig};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// The derivation fixture is the top-level object that contains
 /// everything needed to run a derivation test.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[serde(
+    bound = "RollupConfig: Serialize + DeserializeOwned, L2PayloadAttributes: Serialize + DeserializeOwned, SystemConfig: Serialize + DeserializeOwned, L2BlockInfo: Serialize + DeserializeOwned, Blob: Serialize + DeserializeOwned"
+)]
 #[serde(rename_all = "camelCase")]
-pub struct DerivationFixture {
+pub struct DerivationFixture<
+    RollupConfig: DeserializeOwned,
+    L2PayloadAttributes: DeserializeOwned,
+    SystemConfig: DeserializeOwned,
+    L2BlockInfo: DeserializeOwned,
+    Blob: DeserializeOwned,
+> {
     /// The rollup config.
     pub rollup_config: RollupConfig,
     /// A list of L1 Blocks to derive from.
-    pub l1_blocks: Vec<FixtureBlock>,
+    pub l1_blocks: Vec<FixtureBlock<Blob>>,
     /// A map of L2 block number to l2 payload attributes.
     pub l2_payloads: HashMap<u64, L2PayloadAttributes>,
     /// A map of l2 block number to reference payloads.
@@ -36,8 +44,9 @@ pub struct DerivationFixture {
 /// A fixture block is a minimal block with associated data including blobs
 /// to derive from.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[serde(bound = "Blob: Serialize + DeserializeOwned")]
 #[serde(rename_all = "camelCase")]
-pub struct FixtureBlock {
+pub struct FixtureBlock<Blob: DeserializeOwned> {
     /// The block header.
     /// The entire header is required to generate the block hash when deriving the l1 block info
     /// tx.
@@ -55,9 +64,11 @@ pub struct FixtureBlock {
 mod tests {
     use super::*;
     use alloy_primitives::{address, b256, bytes, uint};
-    use kona_derive::types::{BlockID, BlockInfo};
+    use kona_derive::types::{
+        Blob, BlockID, BlockInfo, L2BlockInfo, L2PayloadAttributes, RollupConfig, SystemConfig,
+    };
 
-    fn ref_blocks() -> Vec<FixtureBlock> {
+    fn ref_blocks() -> Vec<FixtureBlock<Blob>> {
         vec![
             FixtureBlock {
                 header: Header {
@@ -336,7 +347,13 @@ mod tests {
     #[test]
     fn test_derivation_fixture() {
         let fixture_str = include_str!("./testdata/derivation_fixture.json");
-        let fixture: DerivationFixture = serde_json::from_str(fixture_str).unwrap();
+        let fixture: DerivationFixture<
+            RollupConfig,
+            L2PayloadAttributes,
+            SystemConfig,
+            L2BlockInfo,
+            Blob,
+        > = serde_json::from_str(fixture_str).unwrap();
         let expected = DerivationFixture {
             rollup_config: ref_rollup_config(),
             l1_blocks: ref_blocks(),
@@ -353,7 +370,7 @@ mod tests {
     #[test]
     fn test_fixture_block() {
         let fixture_str = include_str!("./testdata/fixture_block.json");
-        let fixture: FixtureBlock = serde_json::from_str(fixture_str).unwrap();
+        let fixture: FixtureBlock<Blob> = serde_json::from_str(fixture_str).unwrap();
         assert_eq!(fixture.header.number, 1);
         assert_eq!(
             fixture.header.parent_hash,

--- a/crates/op-test-vectors/src/lib.rs
+++ b/crates/op-test-vectors/src/lib.rs
@@ -8,10 +8,6 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-// Re-export `kona-derive` since its types are used in derivation fixtures
-// and the crate is pinned to a specific version.
-pub use kona_derive;
-
 pub mod derivation;
 
 pub mod execution;


### PR DESCRIPTION
**Description**

Modifies the `DerivationFixture` making it's internal types generic with deserialization and serialization.

Moves `kona-derive` to a `dev-dependency` in `op-test-vectors` and removes it's re-export.

**Motivation**

Making derivation fixture types generic allows for different versions of `kona-derive` to be used when deserializing the derivation test fixtures. Previously, `kona-derive` was re-exported from `op-test-vectors` causing a conflict in the test runner if using a local, different version of `kona-derive`. This PR solves that by making the types internal so the test runner can import and specify the types from a local import of `kona-derive`.