### PR TITLE
fix: Use Refactored Kona Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,8 +4067,8 @@ dependencies = [
 
 [[package]]
 name = "kona-derive"
-version = "0.0.2"
-source = "git+https://github.com/ethereum-optimism/kona?rev=4e57dd35ea08b31d0baa293c7a12165f28e6cd92#4e57dd35ea08b31d0baa293c7a12165f28e6cd92"
+version = "0.0.3"
+source = "git+https://github.com/ethereum-optimism/kona#19b00f3cf456775197a320aed9e900f110057d2f"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -4077,8 +4077,6 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-client",
- "alloy-rpc-types",
- "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
  "anyhow",
@@ -4091,9 +4089,8 @@ dependencies = [
  "miniz_oxide",
  "op-alloy-consensus",
  "reqwest",
- "revm 10.0.0",
+ "revm 13.0.0",
  "serde",
- "serde_json",
  "sha2",
  "spin",
  "tracing",
@@ -4102,18 +4099,23 @@ dependencies = [
 
 [[package]]
 name = "kona-primitives"
-version = "0.0.1"
-source = "git+https://github.com/ethereum-optimism/kona?rev=4e57dd35ea08b31d0baa293c7a12165f28e6cd92#4e57dd35ea08b31d0baa293c7a12165f28e6cd92"
+version = "0.0.2"
+source = "git+https://github.com/ethereum-optimism/kona#19b00f3cf456775197a320aed9e900f110057d2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-sol-types",
  "anyhow",
+ "c-kzg",
+ "hashbrown",
  "op-alloy-consensus",
+ "revm 13.0.0",
  "serde",
+ "sha2",
+ "spin",
  "superchain-primitives",
+ "tracing",
 ]
 
 [[package]]
@@ -4589,7 +4591,7 @@ dependencies = [
  "anvil-core",
  "color-eyre",
  "hashbrown",
- "kona-derive",
+ "kona-primitives",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "serde",
@@ -4608,6 +4610,7 @@ dependencies = [
  "futures",
  "hashbrown",
  "kona-derive",
+ "kona-primitives",
  "op-test-vectors",
  "reqwest",
  "serde",
@@ -5266,6 +5269,7 @@ dependencies = [
  "color-eyre",
  "futures",
  "kona-derive",
+ "kona-primitives",
  "reqwest",
  "superchain-registry",
  "tokio",
@@ -5443,19 +5447,6 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
-dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter 6.0.0",
- "revm-precompile 8.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm"
 version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6cfb48bce8ca2113e157bdbddbd5eeb09daac1c903d79ec17085897c38c7c91"
@@ -5471,6 +5462,19 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "revm"
+version = "13.0.0"
+source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter 9.0.0",
+ "revm-precompile 10.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -5492,15 +5496,6 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "6.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
-dependencies = [
- "revm-primitives 5.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-interpreter"
 version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b0daddea06fc6da5346acc39b32a357bbe3579e9e3d94117d9ae125cd596fc"
@@ -5510,18 +5505,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-precompile"
-version = "8.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
+name = "revm-interpreter"
+version = "9.0.0"
+source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
 dependencies = [
- "aurora-engine-modexp",
- "c-kzg",
- "k256",
- "once_cell",
- "revm-primitives 5.0.0",
- "ripemd",
- "sha2",
- "substrate-bn",
+ "revm-primitives 8.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -5545,10 +5534,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-primitives"
-version = "5.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
+name = "revm-precompile"
+version = "10.0.0"
+source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
 dependencies = [
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "once_cell",
+ "revm-primitives 8.0.0",
+ "ripemd",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
+dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.6.0",
@@ -5560,15 +5567,15 @@ dependencies = [
  "enumn",
  "hashbrown",
  "hex",
+ "kzg-rs",
  "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
+version = "8.0.0"
+source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ revm = { version = "12.1", features = ["alloydb", "optimism"] }
 
 # Kona + OP Types
 superchain-registry = "0.2.6"
-kona-derive = { git = "https://github.com/ethereum-optimism/kona", rev = "4e57dd35ea08b31d0baa293c7a12165f28e6cd92", features = ["online"] }
+kona-primitives = { git = "https://github.com/ethereum-optimism/kona", version = "0.0.2", features = ["online"] }
+kona-derive = { git = "https://github.com/ethereum-optimism/kona", version = "0.0.3", features = ["online"] }
 
 # Internal
 op-test-vectors = { path = "crates/op-test-vectors" }

--- a/bin/opdn/Cargo.toml
+++ b/bin/opdn/Cargo.toml
@@ -30,5 +30,6 @@ alloy-eips.workspace = true
 
 # OP Types + Kona
 op-test-vectors.workspace = true
+kona-primitives.workspace = true
 kona-derive.workspace = true
 superchain-registry.workspace = true

--- a/bin/opdn/src/cmd/blobs.rs
+++ b/bin/opdn/src/cmd/blobs.rs
@@ -9,7 +9,7 @@ use kona_derive::online::{
     OnlineBeaconClient, OnlineBlobProviderWithFallback, SimpleSlotDerivation,
 };
 use kona_derive::traits::BlobProvider;
-use kona_derive::types::{Blob, BlockInfo, IndexedBlobHash};
+use kona_primitives::{Blob, BlockInfo, IndexedBlobHash};
 
 /// Loads blobs for the given block number.
 pub async fn load(

--- a/bin/opdn/src/cmd/fixtures.rs
+++ b/bin/opdn/src/cmd/fixtures.rs
@@ -8,7 +8,7 @@ use kona_derive::online::{
     AlloyChainProvider, OnlineBeaconClient, OnlineBlobProviderWithFallback, SimpleSlotDerivation,
 };
 use kona_derive::traits::ChainProvider;
-use kona_derive::types::Blob;
+use kona_primitives::Blob;
 use op_test_vectors::derivation::FixtureBlock;
 
 /// Constructs [FixtureBlock]s for the given L1 blocks.

--- a/bin/opdn/src/cmd/from_l1.rs
+++ b/bin/opdn/src/cmd/from_l1.rs
@@ -6,10 +6,8 @@ use color_eyre::{
     Result,
 };
 use hashbrown::HashMap;
-use kona_derive::{
-    online::*,
-    types::{L2BlockInfo, StageError},
-};
+use kona_derive::{errors::StageError, online::*};
+use kona_primitives::L2BlockInfo;
 use op_test_vectors::derivation::DerivationFixture;
 use reqwest::Url;
 use std::path::PathBuf;

--- a/bin/opdn/src/cmd/from_l2.rs
+++ b/bin/opdn/src/cmd/from_l2.rs
@@ -6,10 +6,8 @@ use color_eyre::{
     Result,
 };
 use hashbrown::HashMap;
-use kona_derive::{
-    online::*,
-    types::{L2BlockInfo, StageError},
-};
+use kona_derive::{errors::StageError, online::*};
+use kona_primitives::L2BlockInfo;
 use op_test_vectors::derivation::DerivationFixture;
 use reqwest::Url;
 use std::path::PathBuf;

--- a/bin/opdn/src/cmd/util.rs
+++ b/bin/opdn/src/cmd/util.rs
@@ -1,6 +1,6 @@
 //! Utilities
 
-use kona_derive::types::{L2ExecutionPayloadEnvelope, L2PayloadAttributes, RawTransaction};
+use kona_primitives::{L2ExecutionPayloadEnvelope, L2PayloadAttributes, RawTransaction};
 
 /// Converts an [L2ExecutionPayloadEnvelope] to an [L2PayloadAttributes].
 pub fn to_payload_attributes(payload: L2ExecutionPayloadEnvelope) -> L2PayloadAttributes {

--- a/bin/range-finder/Cargo.toml
+++ b/bin/range-finder/Cargo.toml
@@ -27,4 +27,5 @@ alloy-eips.workspace = true
 
 # OP Types + Kona
 kona-derive.workspace = true
+kona-primitives.workspace = true
 superchain-registry.workspace = true

--- a/bin/range-finder/src/cli.rs
+++ b/bin/range-finder/src/cli.rs
@@ -2,10 +2,8 @@
 
 use clap::{ArgAction, Parser};
 use color_eyre::eyre::{eyre, Result};
-use kona_derive::{
-    online::*,
-    types::{L2BlockInfo, StageError},
-};
+use kona_derive::{errors::StageError, online::*};
+use kona_primitives::L2BlockInfo;
 use reqwest::Url;
 use std::sync::Arc;
 use superchain_registry::ROLLUP_CONFIGS;

--- a/crates/op-test-vectors/Cargo.toml
+++ b/crates/op-test-vectors/Cargo.toml
@@ -29,4 +29,4 @@ op-alloy-consensus.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
-kona-derive.workspace = true
+kona-primitives.workspace = true

--- a/crates/op-test-vectors/src/derivation.rs
+++ b/crates/op-test-vectors/src/derivation.rs
@@ -64,7 +64,7 @@ pub struct FixtureBlock<Blob: DeserializeOwned + Serialize> {
 mod tests {
     use super::*;
     use alloy_primitives::{address, b256, bytes, uint};
-    use kona_derive::types::{
+    use kona_primitives::{
         Blob, BlockID, BlockInfo, L2BlockInfo, L2PayloadAttributes, RollupConfig, SystemConfig,
     };
 


### PR DESCRIPTION
**Description**

Updates crates to use `kona-derive` types refactored into `kona-primitives`.

Reference: https://github.com/ethereum-optimism/kona/pull/454

Also updates kona dependencies to use versioned imports. Once our `release-plz` workflow is working again, we can pull in the published crates instead.